### PR TITLE
🐞 fix: error: has an unfree license (‘unfree’)

### DIFF
--- a/nixos.org
+++ b/nixos.org
@@ -635,31 +635,33 @@ D. Installed through nix-env:
 *** NixOS
 **** Flake.nix
 #+begin_src nix
+{
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
     #nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
   };
-  outputs = { nixpkgs, home-manager, … }:
+  outputs = { nixpkgs, home-manager, ... }:
     let
-      system = “x86_64-linux”;
+      system = "x86_64-linux";
       pkgs = import nixpkgs {
         inherit system;
         config.allowUnfree = true;
       };
 
       lib = nixpkgs.lib;
-   in {
-     nixosConfigurations = {
-       <user> = lib.nixosSystem {
-         inherit system;
-         modules = [ ./configuration.nix ];
-       };
-       #<second user> = lib.nixosSystem {
-         #inherit system;
-         #modules = [ ./configuration.nix ];
-       #};
-     };
-  }
+    in {
+      nixosConfigurations = {
+         <user> = lib.nixosSystem {
+          inherit system pkgs;
+          modules = [ ./configuration.nix ];
+        };
+        #<second user> = lib.nixosSystem {
+        #inherit system;
+        #modules = [ ./configuration.nix ];
+        #};
+      };
+    };
+}
 #+end_src
 
 **** Build


### PR DESCRIPTION
 fix error: not allow Unfree software and add some missing brackets in exp  flake NixOS(line 638)
 
![Screenshot_20221022_223440](https://user-images.githubusercontent.com/51036094/197361990-960cd628-74ce-4066-a416-9fa143e61f03.png)
