### PR TITLE
Switch to nixos-unstable 

### DIFF
--- a/darwin/default.nix
+++ b/darwin/default.nix
@@ -7,11 +7,15 @@
 #       └─ <host>.nix
 #
 
-{ inputs, nixpkgs-unstable, darwin, home-manager-unstable, nixvim-unstable, vars, ... }:
+{ inputs, nixpkgs, nixpkgs-stable, darwin, home-manager, nixvim, vars, ... }:
 
 let
   system = "x86_64-darwin";
-  pkgs = import nixpkgs-unstable {
+  pkgs = import nixpkgs {
+    inherit system;
+    config.allowUnfree = true;
+  };
+  stable = import nixpkgs-stable {
     inherit system;
     config.allowUnfree = true;
   };
@@ -20,14 +24,14 @@ in
   # MacBook8,1 "Core M" 1.2 12" (2015) A1534 ECM2746 profile
   macbook = darwin.lib.darwinSystem {
     inherit system;
-    specialArgs = { inherit inputs pkgs vars; };
+    specialArgs = { inherit inputs system pkgs stable vars; };
     modules = [
-      nixvim-unstable.nixDarwinModules.nixvim
+      nixvim.nixDarwinModules.nixvim
       ./macbook.nix
       ../modules/editors/nvim.nix
       ../modules/programs/kitty.nix
 
-      home-manager-unstable.darwinModules.home-manager
+      home-manager.darwinModules.home-manager
       {
         home-manager.useGlobalPkgs = true;
         home-manager.useUserPackages = true;

--- a/darwin/macbook.nix
+++ b/darwin/macbook.nix
@@ -88,7 +88,7 @@
       options = "--delete-older-than 7d";
     };
     extraOptions = ''
-      auto-optimise-store = true
+      # auto-optimise-store = true
       experimental-features = nix-command flakes
     '';
   };
@@ -126,7 +126,7 @@
     programs = {
       zsh = {
         enable = true;
-        enableAutosuggestions = true;
+        autosuggestion.enable = true;
         syntaxHighlighting.enable = true;
         history.size = 10000;
         oh-my-zsh = {

--- a/flake.lock
+++ b/flake.lock
@@ -3,7 +3,7 @@
     "beautysh": {
       "inputs": {
         "nixpkgs": [
-          "nixvim",
+          "nixvim-stable",
           "nixpkgs"
         ],
         "poetry2nix": "poetry2nix",
@@ -26,15 +26,15 @@
     "darwin": {
       "inputs": {
         "nixpkgs": [
-          "nixpkgs-unstable"
+          "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1713946171,
-        "narHash": "sha256-lc75rgRQLdp4Dzogv5cfqOg6qYc5Rp83oedF2t0kDp8=",
+        "lastModified": 1716240091,
+        "narHash": "sha256-++gJuNv0X8naF1VkaO2sAiM3T4wLx1NtdfubEsRzX7U=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "230a197063de9287128e2c68a7a4b0cd7d0b50a7",
+        "rev": "8bf083c992e2bc0a8c07f5860d3866739b698883",
         "type": "github"
       },
       "original": {
@@ -46,9 +46,9 @@
     },
     "devshell": {
       "inputs": {
-        "flake-utils": "flake-utils_5",
+        "flake-utils": "flake-utils_3",
         "nixpkgs": [
-          "nixvim-unstable",
+          "nixvim",
           "nixpkgs"
         ]
       },
@@ -148,11 +148,11 @@
     "emacs-overlay": {
       "flake": false,
       "locked": {
-        "lastModified": 1715591232,
-        "narHash": "sha256-+5W4dnRnx6XhZMz7e6JTiPyTLMJVj05VmR3n0N/23ic=",
+        "lastModified": 1716256173,
+        "narHash": "sha256-aJo8V/pEvCiF0Cu+PLPnK0FU63yNAELwSiClnaj3swc=",
         "owner": "nix-community",
         "repo": "emacs-overlay",
-        "rev": "cf4f77786a4805f0f815d5859913b03da6009270",
+        "rev": "00193d839cb752bccc8f6508e54afd2dab60c7c9",
         "type": "github"
       },
       "original": {
@@ -274,6 +274,36 @@
       }
     },
     "flake-compat_2": {
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "revCount": 57,
+        "type": "tarball",
+        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.0.1/018afb31-abd1-7bff-a5e4-cff7e18efb7a/source.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
+      }
+    },
+    "flake-compat_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_4": {
       "flake": false,
       "locked": {
         "lastModified": 1673956053,
@@ -289,49 +319,19 @@
         "type": "github"
       }
     },
-    "flake-compat_3": {
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "revCount": 57,
-        "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/edolstra/flake-compat/1.0.1/018afb31-abd1-7bff-a5e4-cff7e18efb7a/source.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://flakehub.com/f/edolstra/flake-compat/1.tar.gz"
-      }
-    },
-    "flake-compat_4": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": [
-          "nixvim-unstable",
+          "nixvim",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1714641030,
-        "narHash": "sha256-yzcRNDoyVP7+SCNX0wmuDju1NUCt8Dz9+lyUXEI0dbI=",
+        "lastModified": 1715865404,
+        "narHash": "sha256-/GJvTdTpuDjNn84j82cU6bXztE0MSkdnTWClUCRub78=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "e5d10a24b66c3ea8f150e47dfdb0416ab7c3390e",
+        "rev": "8dc45382d5206bd292f9c2768b8058a8fd8311d9",
         "type": "github"
       },
       "original": {
@@ -390,7 +390,7 @@
     },
     "flake-utils_3": {
       "inputs": {
-        "systems": "systems_7"
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1701680307,
@@ -408,25 +408,7 @@
     },
     "flake-utils_4": {
       "inputs": {
-        "systems": "systems_8"
-      },
-      "locked": {
-        "lastModified": 1685518550,
-        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_5": {
-      "inputs": {
-        "systems": "systems_9"
+        "systems": "systems_4"
       },
       "locked": {
         "lastModified": 1701680307,
@@ -442,16 +424,16 @@
         "type": "github"
       }
     },
-    "flake-utils_6": {
+    "flake-utils_5": {
       "inputs": {
-        "systems": "systems_10"
+        "systems": "systems_5"
       },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1685518550,
+        "narHash": "sha256-o2d0KcvaXzTrPRIo0kOLV0/QXHhDQ5DTi+OxcjO8xqY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
         "type": "github"
       },
       "original": {
@@ -486,28 +468,6 @@
         ]
       },
       "locked": {
-        "lastModified": 1660459072,
-        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "gitignore_2": {
-      "inputs": {
-        "nixpkgs": [
-          "nixvim-unstable",
-          "pre-commit-hooks",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
         "lastModified": 1709087332,
         "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
         "owner": "hercules-ci",
@@ -521,10 +481,52 @@
         "type": "github"
       }
     },
+    "gitignore_2": {
+      "inputs": {
+        "nixpkgs": [
+          "nixvim-stable",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
     "home-manager": {
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1715930644,
+        "narHash": "sha256-W9pyM3/vePxrffHtzlJI6lDS3seANQ+Nqp+i58O46LI=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "e3ad5108f54177e6520535768ddbf1e6af54b59d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
+    "home-manager-stable": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs-stable"
         ]
       },
       "locked": {
@@ -542,39 +544,19 @@
         "type": "github"
       }
     },
-    "home-manager-unstable": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs-unstable"
-        ]
-      },
-      "locked": {
-        "lastModified": 1715486357,
-        "narHash": "sha256-4pRuzsHZOW5W4CsXI9uhKtiJeQSUoe1d2M9mWU98HC4=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "44677a1c96810a8e8c4ffaeaad10c842402647c1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "type": "github"
-      }
-    },
     "home-manager_2": {
       "inputs": {
         "nixpkgs": [
-          "nixvim-unstable",
+          "nixvim",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1715486357,
-        "narHash": "sha256-4pRuzsHZOW5W4CsXI9uhKtiJeQSUoe1d2M9mWU98HC4=",
+        "lastModified": 1715930644,
+        "narHash": "sha256-W9pyM3/vePxrffHtzlJI6lDS3seANQ+Nqp+i58O46LI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "44677a1c96810a8e8c4ffaeaad10c842402647c1",
+        "rev": "e3ad5108f54177e6520535768ddbf1e6af54b59d",
         "type": "github"
       },
       "original": {
@@ -599,56 +581,34 @@
         ]
       },
       "locked": {
-        "lastModified": 1713612213,
-        "narHash": "sha256-zJboXgWNpNhKyNF8H/3UYzWkx7w00TOCGKi3cwi+tsw=",
+        "lastModified": 1715791817,
+        "narHash": "sha256-J069Uhv/gCMFLX1dSh2f+9ZTM09r1Nv3oUfocCnWKow=",
         "owner": "hyprwm",
         "repo": "hyprcursor",
-        "rev": "cab4746180f210a3c1dd3d53e45c510e309e90e1",
+        "rev": "7c3aa03dffb53921e583ade3d4ae3f487e390e7e",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
         "repo": "hyprcursor",
-        "type": "github"
-      }
-    },
-    "hypridle": {
-      "inputs": {
-        "hyprlang": "hyprlang",
-        "nixpkgs": [
-          "nixpkgs-unstable"
-        ],
-        "systems": "systems_3"
-      },
-      "locked": {
-        "lastModified": 1713472482,
-        "narHash": "sha256-7Ft5WZTMIjXOGgRCf31DZBwK6RK8xkeKlD5vFXz3gII=",
-        "owner": "hyprwm",
-        "repo": "hypridle",
-        "rev": "7cff4581a3753154fc5b41f39a098fad49b777b1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "hypridle",
         "type": "github"
       }
     },
     "hyprland": {
       "inputs": {
         "hyprcursor": "hyprcursor",
-        "hyprlang": "hyprlang_2",
+        "hyprlang": "hyprlang",
         "hyprwayland-scanner": "hyprwayland-scanner",
         "nixpkgs": "nixpkgs",
-        "systems": "systems_4",
+        "systems": "systems_2",
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1715610558,
-        "narHash": "sha256-A9bS/EBc6RQFLAec0sUIUOX8AZShul4aP3U7rj08niM=",
+        "lastModified": 1716295833,
+        "narHash": "sha256-zrVYmWVmJOq4kZQf1s8m4ZY2cZSShb6oE50DR2vzDZc=",
         "ref": "refs/heads/main",
-        "rev": "47874f09f4d14703fe0c483a46b345c7be601ace",
-        "revCount": 4682,
+        "rev": "baef55da1ddccf8ca1b831214bb96e523b600a28",
+        "revCount": 4720,
         "submodules": true,
         "type": "git",
         "url": "https://github.com/hyprwm/Hyprland"
@@ -689,28 +649,6 @@
     "hyprlang": {
       "inputs": {
         "nixpkgs": [
-          "hypridle",
-          "nixpkgs"
-        ],
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1713121246,
-        "narHash": "sha256-502X0Q0fhN6tJK7iEUA8CghONKSatW/Mqj4Wappd++0=",
-        "owner": "hyprwm",
-        "repo": "hyprlang",
-        "rev": "78fcaa27ae9e1d782faa3ff06c8ea55ddce63706",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "hyprlang",
-        "type": "github"
-      }
-    },
-    "hyprlang_2": {
-      "inputs": {
-        "nixpkgs": [
           "hyprland",
           "nixpkgs"
         ],
@@ -720,60 +658,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1713121246,
-        "narHash": "sha256-502X0Q0fhN6tJK7iEUA8CghONKSatW/Mqj4Wappd++0=",
+        "lastModified": 1715791527,
+        "narHash": "sha256-HhQ4zvGHrRjR63ltySSeg+x+0jb0lepiutWdnFhLRoo=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "78fcaa27ae9e1d782faa3ff06c8ea55ddce63706",
+        "rev": "969cb076e5b76f2e823aeca1937a3e1f159812ee",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "type": "github"
-      }
-    },
-    "hyprlang_3": {
-      "inputs": {
-        "nixpkgs": [
-          "hyprlock",
-          "nixpkgs"
-        ],
-        "systems": "systems_5"
-      },
-      "locked": {
-        "lastModified": 1713121246,
-        "narHash": "sha256-502X0Q0fhN6tJK7iEUA8CghONKSatW/Mqj4Wappd++0=",
-        "owner": "hyprwm",
-        "repo": "hyprlang",
-        "rev": "78fcaa27ae9e1d782faa3ff06c8ea55ddce63706",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "hyprlang",
-        "type": "github"
-      }
-    },
-    "hyprlock": {
-      "inputs": {
-        "hyprlang": "hyprlang_3",
-        "nixpkgs": [
-          "nixpkgs-unstable"
-        ],
-        "systems": "systems_6"
-      },
-      "locked": {
-        "lastModified": 1715610114,
-        "narHash": "sha256-ffGEiaL5bVR559adZNHsYBWMefhX8G9oyTrKorbx3h8=",
-        "owner": "hyprwm",
-        "repo": "hyprlock",
-        "rev": "386a1e6fc290fc33177d0b44cd393e32c5433925",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hyprwm",
-        "repo": "hyprlock",
         "type": "github"
       }
     },
@@ -809,11 +703,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1715608589,
-        "narHash": "sha256-vimNaLjLcoNIvBhF37GaB6PRYEvKMamY3UnDE9M5MW8=",
+        "lastModified": 1715879663,
+        "narHash": "sha256-/DwglRvj4XF4ECdNtrCIbthleszAZBwOiXG5A6r0K/c=",
         "owner": "hyprwm",
         "repo": "hyprwayland-scanner",
-        "rev": "65c2636484e5cb00583b8a7446c3fb657f568883",
+        "rev": "f5181a068c1b06f2db51f6222e50a0c665a2b0c3",
         "type": "github"
       },
       "original": {
@@ -825,16 +719,16 @@
     "nix-darwin": {
       "inputs": {
         "nixpkgs": [
-          "nixvim-unstable",
+          "nixvim",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1713946171,
-        "narHash": "sha256-lc75rgRQLdp4Dzogv5cfqOg6qYc5Rp83oedF2t0kDp8=",
+        "lastModified": 1715901937,
+        "narHash": "sha256-eMyvWP56ZOdraC2IOvZo0/RTDcrrsqJ0oJWDC76JTak=",
         "owner": "lnl7",
         "repo": "nix-darwin",
-        "rev": "230a197063de9287128e2c68a7a4b0cd7d0b50a7",
+        "rev": "ffc01182f90118119930bdfc528c1ee9a39ecef8",
         "type": "github"
       },
       "original": {
@@ -882,11 +776,11 @@
     },
     "nixos-hardware": {
       "locked": {
-        "lastModified": 1715148395,
-        "narHash": "sha256-lRxjTxY3103LGMjWdVqntKZHhlmMX12QUjeFrQMmGaE=",
+        "lastModified": 1716173274,
+        "narHash": "sha256-FC21Bn4m6ctajMjiUof30awPBH/7WjD0M5yqrWepZbY=",
         "owner": "nixos",
         "repo": "nixos-hardware",
-        "rev": "a4e2b7909fc1bdf30c30ef21d388fde0b5cdde4a",
+        "rev": "d9e0b26202fd500cf3e79f73653cce7f7d541191",
         "type": "github"
       },
       "original": {
@@ -898,11 +792,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1715534503,
-        "narHash": "sha256-5ZSVkFadZbFP1THataCaSf0JH2cAH3S29hU9rrxTEqk=",
+        "lastModified": 1715787315,
+        "narHash": "sha256-cYApT0NXJfqBkKcci7D9Kr4CBYZKOQKDYA23q8XNuWg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2057814051972fa1453ddfb0d98badbea9b83c06",
+        "rev": "33d1e753c82ffc557b4a585c77de43d4c922ebb5",
         "type": "github"
       },
       "original": {
@@ -913,6 +807,22 @@
       }
     },
     "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1716218643,
+        "narHash": "sha256-i/E7gzQybvcGAYDRGDl39WL6yVk30Je/NXypBz6/nmM=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a8695cbd09a7ecf3376bd62c798b9864d20f86ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable_2": {
       "locked": {
         "lastModified": 1685801374,
         "narHash": "sha256-otaSUoFEMM+LjBI1XL/xGB5ao6IwnZOXc47qhIgJe8U=",
@@ -928,13 +838,13 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable": {
+    "nixpkgs_2": {
       "locked": {
-        "lastModified": 1715534503,
-        "narHash": "sha256-5ZSVkFadZbFP1THataCaSf0JH2cAH3S29hU9rrxTEqk=",
+        "lastModified": 1716137900,
+        "narHash": "sha256-sowPU+tLQv8GlqtVtsXioTKeaQvlMz/pefcdwg8MvfM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "2057814051972fa1453ddfb0d98badbea9b83c06",
+        "rev": "6c0b7a92c30122196a761b440ac0d46d3d9954f1",
         "type": "github"
       },
       "original": {
@@ -944,30 +854,42 @@
         "type": "github"
       }
     },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1715542476,
-        "narHash": "sha256-FF593AtlzQqa8JpzrXyRws4CeKbc5W86o8tHt4nRfIg=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "44072e24566c5bcc0b7aa9178a0104f4cfffab19",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-23.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixvim": {
       "inputs": {
-        "beautysh": "beautysh",
-        "flake-utils": "flake-utils_3",
+        "devshell": "devshell",
+        "flake-compat": "flake-compat_2",
+        "flake-parts": "flake-parts",
+        "flake-root": "flake-root",
+        "home-manager": "home-manager_2",
+        "nix-darwin": "nix-darwin",
         "nixpkgs": [
           "nixpkgs"
         ],
-        "pre-commit-hooks": "pre-commit-hooks"
+        "pre-commit-hooks": "pre-commit-hooks",
+        "treefmt-nix": "treefmt-nix"
+      },
+      "locked": {
+        "lastModified": 1716294469,
+        "narHash": "sha256-1RdJkVa+axdzLhbeoWJoC3BPODxfx+/Rv7HE+e4CK/Y=",
+        "owner": "nix-community",
+        "repo": "nixvim",
+        "rev": "1c9f2a23a6cb9406c35980f4af1a4356f56771e9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixvim",
+        "type": "github"
+      }
+    },
+    "nixvim-stable": {
+      "inputs": {
+        "beautysh": "beautysh",
+        "flake-utils": "flake-utils_4",
+        "nixpkgs": [
+          "nixpkgs-stable"
+        ],
+        "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {
         "lastModified": 1713951100,
@@ -980,34 +902,6 @@
       "original": {
         "owner": "nix-community",
         "ref": "nixos-23.11",
-        "repo": "nixvim",
-        "type": "github"
-      }
-    },
-    "nixvim-unstable": {
-      "inputs": {
-        "devshell": "devshell",
-        "flake-compat": "flake-compat_3",
-        "flake-parts": "flake-parts",
-        "flake-root": "flake-root",
-        "home-manager": "home-manager_2",
-        "nix-darwin": "nix-darwin",
-        "nixpkgs": [
-          "nixpkgs-unstable"
-        ],
-        "pre-commit-hooks": "pre-commit-hooks_2",
-        "treefmt-nix": "treefmt-nix"
-      },
-      "locked": {
-        "lastModified": 1715582453,
-        "narHash": "sha256-pW8a12PHt/PUphG8Tn0nb+mfbTS7JS4YbThGPepCcb0=",
-        "owner": "nix-community",
-        "repo": "nixvim",
-        "rev": "4530a35bad28a0e8b21905b0817a225e6387811c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
         "repo": "nixvim",
         "type": "github"
       }
@@ -1030,11 +924,11 @@
     },
     "nur": {
       "locked": {
-        "lastModified": 1715611234,
-        "narHash": "sha256-i7zIWbB8ohyStvfWsyLTEL4MYOVL9ZUHEdlAiapo6P4=",
+        "lastModified": 1716302211,
+        "narHash": "sha256-n4E22rDCv73/4mV2X2YdYnVkPujHCKk2ycBZLaQYFbA=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "323f4977a915d531bcf6ca0fd86d6e18c53070e4",
+        "rev": "4e9b630d2e016099a359688e826b14eb002fae8f",
         "type": "github"
       },
       "original": {
@@ -1133,11 +1027,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714856962,
-        "narHash": "sha256-2te5GG8TVNBF44uMF4G0XFGW+Jt02i/ZkspSNFzjgT0=",
+        "lastModified": 1716145823,
+        "narHash": "sha256-S2cfXdWCRf6Z+Gas6GN1kMSYqG01583uuJKITDVQp0o=",
         "owner": "pjones",
         "repo": "plasma-manager",
-        "rev": "1554e19ede17de46106dd95820eeea05086a5720",
+        "rev": "5db76cbb4d66231769cd8939472ae00c55c24a44",
         "type": "github"
       },
       "original": {
@@ -1149,12 +1043,12 @@
     "poetry2nix": {
       "inputs": {
         "flake-utils": [
-          "nixvim",
+          "nixvim-stable",
           "beautysh",
           "utils"
         ],
         "nixpkgs": [
-          "nixvim",
+          "nixvim-stable",
           "beautysh",
           "nixpkgs"
         ]
@@ -1175,21 +1069,23 @@
     },
     "pre-commit-hooks": {
       "inputs": {
-        "flake-compat": "flake-compat_2",
-        "flake-utils": "flake-utils_4",
+        "flake-compat": "flake-compat_3",
         "gitignore": "gitignore",
         "nixpkgs": [
           "nixvim",
           "nixpkgs"
         ],
-        "nixpkgs-stable": "nixpkgs-stable"
+        "nixpkgs-stable": [
+          "nixvim",
+          "nixpkgs"
+        ]
       },
       "locked": {
-        "lastModified": 1703939133,
-        "narHash": "sha256-Gxe+mfOT6bL7wLC/tuT2F+V+Sb44jNr8YsJ3cyIl4Mo=",
+        "lastModified": 1715870890,
+        "narHash": "sha256-nacSOeXtUEM77Gn0G4bTdEOeFIrkCBXiyyFZtdGwuH0=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "9d3d7e18c6bc4473d7520200d4ddab12f8402d38",
+        "rev": "fa606cccd7b0ccebe2880051208e4a0f61bfc8c1",
         "type": "github"
       },
       "original": {
@@ -1201,23 +1097,20 @@
     "pre-commit-hooks_2": {
       "inputs": {
         "flake-compat": "flake-compat_4",
-        "flake-utils": "flake-utils_6",
+        "flake-utils": "flake-utils_5",
         "gitignore": "gitignore_2",
         "nixpkgs": [
-          "nixvim-unstable",
+          "nixvim-stable",
           "nixpkgs"
         ],
-        "nixpkgs-stable": [
-          "nixvim-unstable",
-          "nixpkgs"
-        ]
+        "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
-        "lastModified": 1714478972,
-        "narHash": "sha256-q//cgb52vv81uOuwz1LaXElp3XAe1TqrABXODAEF6Sk=",
+        "lastModified": 1703939133,
+        "narHash": "sha256-Gxe+mfOT6bL7wLC/tuT2F+V+Sb44jNr8YsJ3cyIl4Mo=",
         "owner": "cachix",
         "repo": "pre-commit-hooks.nix",
-        "rev": "2849da033884f54822af194400f8dff435ada242",
+        "rev": "9d3d7e18c6bc4473d7520200d4ddab12f8402d38",
         "type": "github"
       },
       "original": {
@@ -1248,17 +1141,15 @@
         "doom-emacs": "doom-emacs",
         "emacs-overlay": "emacs-overlay",
         "home-manager": "home-manager",
-        "home-manager-unstable": "home-manager-unstable",
-        "hypridle": "hypridle",
+        "home-manager-stable": "home-manager-stable",
         "hyprland": "hyprland",
-        "hyprlock": "hyprlock",
         "hyprspace": "hyprspace",
         "nixgl": "nixgl",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_2",
-        "nixpkgs-unstable": "nixpkgs-unstable",
+        "nixpkgs-stable": "nixpkgs-stable",
         "nixvim": "nixvim",
-        "nixvim-unstable": "nixvim-unstable",
+        "nixvim-stable": "nixvim-stable",
         "nur": "nur",
         "plasma-manager": "plasma-manager"
       }
@@ -1310,21 +1201,6 @@
         "type": "github"
       }
     },
-    "systems_10": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "systems_2": {
       "locked": {
         "lastModified": 1689347949,
@@ -1342,95 +1218,35 @@
     },
     "systems_3": {
       "locked": {
-        "lastModified": 1689347949,
-        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
         "owner": "nix-systems",
-        "repo": "default-linux",
-        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
-        "repo": "default-linux",
+        "repo": "default",
         "type": "github"
       }
     },
     "systems_4": {
       "locked": {
-        "lastModified": 1689347949,
-        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
         "owner": "nix-systems",
-        "repo": "default-linux",
-        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
         "type": "github"
       },
       "original": {
         "owner": "nix-systems",
-        "repo": "default-linux",
+        "repo": "default",
         "type": "github"
       }
     },
     "systems_5": {
-      "locked": {
-        "lastModified": 1689347949,
-        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
-        "owner": "nix-systems",
-        "repo": "default-linux",
-        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default-linux",
-        "type": "github"
-      }
-    },
-    "systems_6": {
-      "locked": {
-        "lastModified": 1689347949,
-        "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
-        "owner": "nix-systems",
-        "repo": "default-linux",
-        "rev": "31732fcf5e8fea42e59c2488ad31a0e651500f68",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default-linux",
-        "type": "github"
-      }
-    },
-    "systems_7": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_8": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_9": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -1448,16 +1264,16 @@
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
-          "nixvim-unstable",
+          "nixvim",
           "nixpkgs"
         ]
       },
       "locked": {
-        "lastModified": 1714058656,
-        "narHash": "sha256-Qv4RBm4LKuO4fNOfx9wl40W2rBbv5u5m+whxRYUMiaA=",
+        "lastModified": 1715940852,
+        "narHash": "sha256-wJqHMg/K6X3JGAE9YLM0LsuKrKb4XiBeVaoeMNlReZg=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "c6aaf729f34a36c445618580a9f95a48f5e4e03f",
+        "rev": "2fba33a182602b9d49f0b2440513e5ee091d838b",
         "type": "github"
       },
       "original": {
@@ -1530,11 +1346,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1714662532,
-        "narHash": "sha256-Pj2xGSYhapYbXL7sk7TTlOtCZcTfPQoL3fPbZeg7L4Y=",
+        "lastModified": 1715788457,
+        "narHash": "sha256-32HOkjSIyANphV0p5gIwP4ONU/CcinhwOyVFB+tL/d0=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "1f228ba2f1f254195c0b571302b37482861abee3",
+        "rev": "af7c87a32f5d67eb2ada908a6a700f4e74831943",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -13,26 +13,33 @@
 
   inputs =
     {
-      nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11"; # Nix Packages (Default)
-      nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable"; # Unstable Nix Packages
+      nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable"; # Nix Packages (Default)
+      # nixpkgs-unstable.url = "github:nixos/nixpkgs/nixos-unstable"; # Unstable Nix Packages
+      nixpkgs-stable.url = "github:nixos/nixpkgs/nixos-23.11"; # Unstable Nix Packages
       nixos-hardware.url = "github:nixos/nixos-hardware/master"; # Hardware Specific Configurations
 
       # User Environment Manager
       home-manager = {
-        url = "github:nix-community/home-manager/release-23.11";
+        url = "github:nix-community/home-manager";
         inputs.nixpkgs.follows = "nixpkgs";
       };
 
       # Unstable User Environment Manager
-      home-manager-unstable = {
-        url = "github:nix-community/home-manager";
-        inputs.nixpkgs.follows = "nixpkgs-unstable";
+      # home-manager-unstable = {
+      #   url = "github:nix-community/home-manager";
+      #   inputs.nixpkgs.follows = "nixpkgs-unstable";
+      # };
+
+      # Stable User Environment Manager
+      home-manager-stable = {
+        url = "github:nix-community/home-manager/release-23.11";
+        inputs.nixpkgs.follows = "nixpkgs-stable";
       };
 
       # MacOS Package Management
       darwin = {
         url = "github:lnl7/nix-darwin/master";
-        inputs.nixpkgs.follows = "nixpkgs-unstable";
+        inputs.nixpkgs.follows = "nixpkgs";
       };
 
       # NUR Community Packages
@@ -49,14 +56,14 @@
 
       # Neovim
       nixvim = {
-        url = "github:nix-community/nixvim/nixos-23.11";
+        url = "github:nix-community/nixvim";
         inputs.nixpkgs.follows = "nixpkgs";
       };
 
       # Neovim
-      nixvim-unstable = {
-        url = "github:nix-community/nixvim";
-        inputs.nixpkgs.follows = "nixpkgs-unstable";
+      nixvim-stable = {
+        url = "github:nix-community/nixvim/nixos-23.11";
+        inputs.nixpkgs.follows = "nixpkgs-stable";
       };
 
       # Emacs Overlays
@@ -77,18 +84,6 @@
         url = "git+https://github.com/hyprwm/Hyprland?submodules=1";
       };
 
-      # Hyprlock
-      hyprlock = {
-        url = "github:hyprwm/hyprlock";
-        inputs.nixpkgs.follows = "nixpkgs-unstable";
-      };
-
-      # Hypridle
-      hypridle = {
-        url = "github:hyprwm/hypridle";
-        inputs.nixpkgs.follows = "nixpkgs-unstable";
-      };
-
       # Hyprspace
       hyprspace = {
         url = "github:KZDKM/Hyprspace";
@@ -103,7 +98,7 @@
       };
     };
 
-  outputs = inputs @ { self, nixpkgs, nixpkgs-unstable, nixos-hardware, home-manager, home-manager-unstable, darwin, nur, nixgl, nixvim, nixvim-unstable, doom-emacs, hyprland, hyprlock, hypridle, hyprspace, plasma-manager, ... }: # Function telling flake which inputs to use
+  outputs = inputs @ { self, nixpkgs, nixpkgs-stable, nixos-hardware, home-manager, home-manager-stable, darwin, nur, nixgl, nixvim, nixvim-stable, doom-emacs, hyprland, hyprspace, plasma-manager, ... }: # Function telling flake which inputs to use
     let
       # Variables Used In Flake
       vars = {
@@ -117,21 +112,21 @@
       nixosConfigurations = (
         import ./hosts {
           inherit (nixpkgs) lib;
-          inherit inputs nixpkgs nixpkgs-unstable nixos-hardware home-manager nur nixvim doom-emacs hyprland hyprlock hypridle hyprspace plasma-manager vars; # Inherit inputs
+          inherit inputs nixpkgs nixpkgs-stable nixos-hardware home-manager nur nixvim doom-emacs hyprland hyprspace plasma-manager vars; # Inherit inputs
         }
       );
 
       darwinConfigurations = (
         import ./darwin {
           inherit (nixpkgs) lib;
-          inherit inputs nixpkgs-unstable home-manager-unstable darwin nixvim-unstable vars;
+          inherit inputs nixpkgs nixpkgs-stable home-manager darwin nixvim vars;
         }
       );
 
       homeConfigurations = (
         import ./nix {
           inherit (nixpkgs) lib;
-          inherit inputs nixpkgs nixpkgs-unstable home-manager nixgl vars;
+          inherit inputs nixpkgs nixpkgs-stable home-manager nixgl vars;
         }
       );
     };

--- a/hosts/beelink/default.nix
+++ b/hosts/beelink/default.nix
@@ -16,7 +16,7 @@
 #  NOTE: Dual booted with windows 11. Disable fast-boot in power plan and bios and turn off hibernate to get wifi and bluetooth working. This only works once but on reboot is borked again. So using the old school BLT dongle.
 #
 
-{ pkgs, unstable, ... }:
+{ pkgs, ... }:
 
 {
   imports = [
@@ -70,12 +70,10 @@
       moonlight-qt # Remote Streaming
       obs-studio # Live Streaming
       plex-media-player # Media Player
+      prusa-slicer # 3D Slicer
       rclone # Gdrive ($ rclone config | rclone mount --daemon gdrive:<path> <host/path>)
       simple-scan # Scanning
-    ] ++
-    (with unstable; [
-      prusa-slicer
-    ]);
+    ];
   };
 
   flatpak = {

--- a/hosts/beelink/hardware-configuration.nix
+++ b/hosts/beelink/hardware-configuration.nix
@@ -67,7 +67,7 @@
   hardware.cpu.intel.updateMicrocode = lib.mkDefault config.hardware.enableRedistributableFirmware;
 
   networking = with host; {
-    useDHCP = true;
+    useDHCP = lib.mkDefault true;
     hostName = hostName;
     bridges = {
       "br0" = {

--- a/hosts/configuration.nix
+++ b/hosts/configuration.nix
@@ -22,7 +22,7 @@
 #           └─ default.nix
 #
 
-{ pkgs, unstable, inputs, vars, ... }:
+{ pkgs, stable, inputs, vars, ... }:
 
 let
   terminal = pkgs.${vars.terminal};
@@ -114,7 +114,6 @@ in
       # Video/Audio
       alsa-utils # Audio Control
       feh # Image Viewer
-      image-roll # Image Viewer
       linux-firmware # Proprietary Hardware Blob
       mpv # Media Player
       pavucontrol # Audio Control
@@ -143,9 +142,10 @@ in
       # - ./<host>/default.nix
       # - ../modules
     ] ++
-    (with unstable; [
+    (with stable; [
       # Apps
       # firefox # Browser
+      image-roll # Image Viewer
     ]);
   };
 
@@ -187,7 +187,7 @@ in
       dates = "weekly";
       options = "--delete-older-than 2d";
     };
-    package = pkgs.nixVersions.unstable;
+    # package = pkgs.nixVersions.latest;
     registry.nixpkgs.flake = inputs.nixpkgs;
     extraOptions = ''
       experimental-features = nix-command flakes
@@ -242,7 +242,7 @@ in
       };
       desktopEntries.image-roll = {
         name = "image-roll";
-        exec = "${pkgs.image-roll}/bin/image-roll %F";
+        exec = "${stable.image-roll}/bin/image-roll %F";
         mimeType = [ "image/*" ];
       };
       desktopEntries.gmail = {

--- a/hosts/default.nix
+++ b/hosts/default.nix
@@ -9,7 +9,7 @@
 #           └─ default.nix
 #
 
-{ inputs, nixpkgs, nixpkgs-unstable, nixos-hardware, home-manager, nur, nixvim, doom-emacs, hyprland, hyprlock, hypridle, hyprspace, plasma-manager, vars, ... }:
+{ inputs, nixpkgs, nixpkgs-stable, nixos-hardware, home-manager, nur, nixvim, doom-emacs, hyprland, hyprspace, plasma-manager, vars, ... }:
 
 let
   system = "x86_64-linux";
@@ -19,7 +19,7 @@ let
     config.allowUnfree = true;
   };
 
-  unstable = import nixpkgs-unstable {
+  stable = import nixpkgs-stable {
     inherit system;
     config.allowUnfree = true;
   };
@@ -31,11 +31,11 @@ in
   beelink = lib.nixosSystem {
     inherit system;
     specialArgs = {
-      inherit inputs system unstable hyprland hyprlock hypridle hyprspace vars;
+      inherit inputs system stable hyprland hyprspace vars;
       host = {
         hostName = "beelink";
-        mainMonitor = "HDMI-A-1";
-        secondMonitor = "HDMI-A-2";
+        mainMonitor = "HDMI-A-2";
+        secondMonitor = "HDMI-A-1";
       };
     };
     modules = [
@@ -56,7 +56,7 @@ in
   work = lib.nixosSystem {
     inherit system;
     specialArgs = {
-      inherit inputs system unstable hyprland hyprlock hypridle hyprspace vars;
+      inherit inputs system stable hyprland hyprspace vars;
       host = {
         hostName = "work";
         mainMonitor = "eDP-1";
@@ -81,7 +81,7 @@ in
   xps = lib.nixosSystem {
     inherit system;
     specialArgs = {
-      inherit inputs system unstable hyprland hyprlock hypridle hyprspace vars;
+      inherit inputs system stable hyprland hyprspace vars;
       host = {
         hostName = "xps";
         mainMonitor = "eDP-1";
@@ -107,7 +107,7 @@ in
   vm = lib.nixosSystem {
     inherit system;
     specialArgs = {
-      inherit inputs unstable vars;
+      inherit inputs system stable vars;
       host = {
         hostName = "vm";
         mainMonitor = "Virtual-1";
@@ -131,7 +131,7 @@ in
   h310m = lib.nixosSystem {
     inherit system;
     specialArgs = {
-      inherit inputs system unstable hyprland hyprlock hypridle hyprspace vars;
+      inherit inputs system stable hyprland hyprspace vars;
       host = {
         hostName = "h310m";
         mainMonitor = "HDMI-A-1";
@@ -159,7 +159,7 @@ in
   probook = lib.nixosSystem {
     inherit system;
     specialArgs = {
-      inherit inputs unstable vars;
+      inherit inputs system stable vars;
       host = {
         hostName = "probook";
         mainMonitor = "eDP-1";

--- a/hosts/xps/hardware-configuration.nix
+++ b/hosts/xps/hardware-configuration.nix
@@ -47,10 +47,10 @@
     enableIPv6 = false;
     networkmanager = {
       enable = true;
-      extraConfig = ''
-        [main]
-        rc-manager=resolvconf
-      '';
+      # extraConfig = ''
+      #   [main]
+      #   rc-manager=resolvconf
+      # '';
     };
     nameservers = [ "192.168.0.4" "1.1.1.1" ];
     firewall.enable = false;

--- a/modules/desktops/bspwm.nix
+++ b/modules/desktops/bspwm.nix
@@ -70,20 +70,22 @@ in
       x11wm.enable = true;
 
       services = {
+        displayManager.defaultSession = "none+bspwm";
+        libinput = {
+          enable = true;
+          touchpad = {
+            tapping = true;
+            scrollMethod = "twofinger";
+            naturalScrolling = true;
+            accelProfile = "adaptive";
+            disableWhileTyping = true;
+          };
+        };
         xserver = {
           enable = true;
-
-          layout = "us";
-          xkbOptions = "eurosign:e";
-          libinput = {
-            enable = true;
-            touchpad = {
-              tapping = true;
-              scrollMethod = "twofinger";
-              naturalScrolling = true;
-              accelProfile = "adaptive";
-              disableWhileTyping = true;
-            };
+          xkb = {
+            layout = "us";
+            options = "eurosign:e";
           };
           modules = [ pkgs.xf86_input_wacom ];
           wacom.enable = true;
@@ -106,7 +108,6 @@ in
                 };
               };
             };
-            defaultSession = "none+bspwm";
           };
           windowManager.bspwm = {
             enable = true;

--- a/modules/desktops/gnome.nix
+++ b/modules/desktops/gnome.nix
@@ -26,12 +26,13 @@ with lib;
     };
 
     services = {
+      libinput.enable = true;
       xserver = {
         enable = true;
-
-        layout = "us";
-        xkbOptions = "eurosign:e";
-        libinput.enable = true;
+        xkb = {
+          layout = "us";
+          options = "eurosign:e";
+        };
         modules = [ pkgs.xf86_input_wacom ];
         wacom.enable = true;
 
@@ -47,6 +48,7 @@ with lib;
       systemPackages = with pkgs; [
         gnome.adwaita-icon-theme
         gnome.dconf-editor
+        gedit
         gnome.gnome-tweaks
       ];
       gnome.excludePackages = (with pkgs; [
@@ -55,7 +57,6 @@ with lib;
         atomix
         epiphany
         geary
-        gedit
         gnome-characters
         gnome-contacts
         gnome-initial-setup
@@ -98,7 +99,6 @@ with lib;
             "clipboard-indicator@tudmotu.com"
             "horizontal-workspace-indicator@tty2.io"
             "bluetooth-quick-connect@bjarosze.gmail.com"
-            "battery-indicator@jgotti.org"
             "gsconnect@andyholmes.github.io"
             "pip-on-top@rafostar.github.com"
             "forge@jmmaranan.com"
@@ -281,7 +281,7 @@ with lib;
         blur-my-shell
         removable-drive-menu
         dash-to-panel
-        battery-indicator-upower
+        upower-battery
         just-perfection
         caffeine
         clipboard-indicator

--- a/modules/desktops/kde.nix
+++ b/modules/desktops/kde.nix
@@ -27,19 +27,20 @@ with lib;
     };
 
     services = {
+      displayManager = {
+        sddm.enable = true;
+        defaultSession = "plasmawayland";
+      };
+      libinput.enable = true;
       xserver = {
         enable = true;
-
-        layout = "us";
-        xkbOptions = "eurosign:e";
-        libinput.enable = true;
+        xkb = {
+          layout = "us";
+          options = "eurosign:e";
+        };
         modules = [ pkgs.xf86_input_wacom ];
         wacom.enable = true;
 
-        displayManager = {
-          sddm.enable = true;
-          defaultSession = "plasmawayland";
-        };
         desktopManager.plasma5 = {
           enable = true;
         };

--- a/modules/editors/nvim.nix
+++ b/modules/editors/nvim.nix
@@ -1,12 +1,17 @@
-{ pkgs, ... }:
+{ config, lib, system, pkgs, stable, vars, ... }:
 
 let
   colors = import ../theming/colors.nix;
 
-  dutch = builtins.readFile (builtins.fetchurl {
-    url = "https://raw.githubusercontent.com/OpenTaal/opentaal-wordlist/master/wordlist.txt";
-    sha256 = "1gnpkb2afasbcfka6lhnpzlpafpns4k6j09h7dc0p13k7iggpr8j";
-  });
+  nvim-spell-nl-utf8-dictionary = builtins.fetchurl {
+    url = "http://ftp.vim.org/vim/runtime/spell/nl.utf-8.spl";
+    sha256 = "sha256:1v4knd9i4zf3lhacnkmhxrq0lgk9aj4iisbni9mxi1syhs4lfgni";
+  };
+
+  nvim-spell-nl-utf8-suggestions = builtins.fetchurl {
+    url = "http://ftp.vim.org/vim/runtime/spell/nl.utf-8.sug";
+    sha256 = "sha256:0clvhlg52w4iqbf5sr4bb3lzja2ch1dirl0963d5vlg84wzc809y";
+  };
 in
 {
   # # steam-run for codeium-vim
@@ -23,18 +28,11 @@ in
       ripgrep
       zig
     ];
-    wordlist = {
-      enable = true;
-      lists = {
-        WORDLIST = [
-          "${pkgs.scowl}/share/dict/words.txt"
-          (builtins.toFile "dutch" dutch)
-        ];
-      };
-    };
   };
+
   programs.nixvim = {
     enable = true;
+    enableMan = false;
     viAlias = true;
     vimAlias = true;
     autoCmd = [
@@ -74,7 +72,7 @@ in
       }
     ];
 
-    options = {
+    opts = {
       number = true;
       relativenumber = true;
       hidden = true;
@@ -94,11 +92,8 @@ in
       timeoutlen = 2500;
       conceallevel = 3;
       cursorline = true;
-    };
-
-    colorschemes.onedark = {
-      enable = true;
-      package = pkgs.vimPlugins.onedarkpro-nvim;
+      spell = true;
+      spelllang = [ "nl" "en" ];
     };
 
     clipboard = {
@@ -316,15 +311,18 @@ in
           move = { };
         };
       };
-      indent-blankline.enable = true;
+      indent-blankline = {
+        enable = true;
+        settings.scope.enabled = false;
+      };
       lastplace.enable = true;
-      comment-nvim.enable = true;
+      comment.enable = true;
       fugitive.enable = true;
       markdown-preview.enable = true;
       nvim-autopairs.enable = true;
       telescope = {
         enable = true;
-        extraOptions = {
+        settings = {
           pickers.find_files = {
             hidden = true;
           };
@@ -332,19 +330,27 @@ in
         keymaps = {
           "<leader>ff" = {
             action = "find_files";
-            desc = "Find File";
+            options = {
+              desc = "Find File";
+            };
           };
           "<leader>fg" = {
             action = "live_grep";
-            desc = "Find Via Grep";
+            options = {
+              desc = "Find Via Grep";
+            };
           };
           "<leader>fb" = {
             action = "buffers";
-            desc = "Find Buffers";
+            options = {
+              desc = "Find Buffers";
+            };
           };
           "<leader>fh" = {
             action = "help_tags";
-            desc = "Find Help";
+            options = {
+              desc = "Find Help";
+            };
           };
         };
       };
@@ -362,8 +368,10 @@ in
       };
       undotree = {
         enable = true;
-        focusOnToggle = true;
-        highlightChangedText = true;
+        settings = {
+          FocusOnToggle = true;
+          HighlightChangedText = true;
+        };
       };
       treesitter = {
         enable = true;
@@ -399,6 +407,7 @@ in
       };
       neorg = {
         enable = true;
+        package = stable.vimPlugins.neorg;
         lazyLoading = true;
         modules = {
           "core.defaults".__empty = null;
@@ -469,51 +478,34 @@ in
       cmp_luasnip.enable = true;
       cmp-nvim-lsp.enable = true;
       cmp-look.enable = true;
-      nvim-cmp = {
+      cmp = {
         enable = true;
-        snippet.expand = "luasnip";
-        mapping = {
-          "<C-d>" = "cmp.mapping.scroll_docs(-4)";
-          "<C-f>" = "cmp.mapping.scroll_docs(4)";
-          "<C-Space>" = "cmp.mapping.complete()";
-          "<C-e>" = "cmp.mapping.close()";
-          # "<Tab>" = {
-          #   modes = ["i" "s"];
-          #   action = "cmp.mapping.select_next_item()";
-          # };
-          # "<S-Tab>" = {
-          #   modes = ["i" "s"];
-          #   action = "cmp.mapping.select_prev_item()";
-          # };
-          "<Down>" = {
-            modes = [ "i" "s" ];
-            action = "cmp.mapping.select_next_item()";
+        settings = {
+          snippet.expand = "luasnip";
+          mapping = {
+            "<C-d>" = "cmp.mapping.scroll_docs(-4)";
+            "<C-f>" = "cmp.mapping.scroll_docs(4)";
+            "<C-Space>" = "cmp.mapping.complete()";
+            "<C-e>" = "cmp.mapping.close()";
+            # "<Tab>" = "cmp.mapping(cmp.mapping.select_next_item(), {'i', 's'})";
+            # "<S-Tab>" = "cmp.mapping(cmp.mapping.select_prev_item(), {'i', 's'})";
+            "<Down>" = "cmp.mapping(cmp.mapping.select_next_item(), {'i', 's'})";
+            "<Up>" = "cmp.mapping(cmp.mapping.select_prev_item(), {'i', 's'})";
+            "<C-j>" = "cmp.mapping(cmp.mapping.select_next_item(), {'i', 's'})";
+            "<C-k>" = "cmp.mapping(cmp.mapping.select_prev_item(), {'i', 's'})";
+            "<Tab>" = "cmp.mapping.confirm({ select = true })";
           };
-          "<Up>" = {
-            modes = [ "i" "s" ];
-            action = "cmp.mapping.select_prev_item()";
-          };
-          "<C-j>" = {
-            modes = [ "i" "s" ];
-            action = "cmp.mapping.select_next_item()";
-          };
-          "<C-k>" = {
-            modes = [ "i" "s" ];
-            action = "cmp.mapping.select_prev_item()";
-          };
-          # "<CR>" = "cmp.mapping.confirm({ select = true })";
-          "<Tab>" = "cmp.mapping.confirm({ select = true })";
+          sources = [
+            { name = "nvim_lsp"; }
+            { name = "luasnip"; }
+            { name = "look"; keywordLength = 2; option = { convert_case = true; loud = true; }; }
+            { name = "path"; }
+            { name = "buffer"; }
+            { name = "nvim_lua"; }
+            { name = "orgmode"; }
+            { name = "neorg"; }
+          ];
         };
-        sources = [
-          { name = "nvim_lsp"; }
-          { name = "luasnip"; }
-          { name = "look"; keywordLength = 2; option = { convert_case = true; loud = true; }; }
-          { name = "path"; }
-          { name = "buffer"; }
-          { name = "nvim_lua"; }
-          { name = "orgmode"; }
-          { name = "neorg"; }
-        ];
       };
       which-key = {
         enable = true;
@@ -526,11 +518,13 @@ in
       };
       toggleterm = {
         enable = true;
-        autoScroll = true;
-        closeOnExit = true;
-        direction = "horizontal";
-        persistMode = true;
-        startInInsert = true;
+        settings = {
+          autoScroll = true;
+          closeOnExit = true;
+          direction = "horizontal";
+          persistMode = true;
+          startInInsert = true;
+        };
       };
     };
     extraPlugins = with pkgs.vimPlugins; [
@@ -538,6 +532,7 @@ in
       luasnip
       nvim-scrollbar
       orgmode
+      onedarkpro-nvim
       vim-cool
       vim-prettier
       vim-table-mode
@@ -573,8 +568,7 @@ in
         };
       })
     ];
-    extraConfigLua = ''
-      require('luasnip.loaders.from_vscode').lazy_load()
+    extraConfigLua = with colors.scheme.default.hex; ''
       require('orgmode').setup({
         org_agenda_files = { '~/org/**/*' },
         org_default_notes_file = '~/org/refile.org',
@@ -588,12 +582,6 @@ in
         augroup END
       ]]
 
-      require('org-bullets').setup()
-
-      require('scrollbar').setup()
-    '';
-    extraConfigLuaPre = with colors.scheme.default.hex; ''
-      require('orgmode').setup_ts_grammar()
       require('onedarkpro').setup({
         colors = {
           bg = "#${bg}",
@@ -602,6 +590,18 @@ in
           cursorline = true,
         },
       })
+      vim.cmd[[
+        colorscheme onedark
+      ]]
+
+      require('org-bullets').setup()
+
+      require('scrollbar').setup()
     '';
+  };
+
+  home-manager.users.${vars.user} = {
+    home.file.".config/nvim/spell/nl.utf-8.spl".source = nvim-spell-nl-utf8-dictionary;
+    home.file.".config/nvim/spell/nl.utf-8.sug".source = nvim-spell-nl-utf8-suggestions;
   };
 }

--- a/modules/hardware/work/nvidia.nix
+++ b/modules/hardware/work/nvidia.nix
@@ -17,13 +17,15 @@ let
   '';
 in
 {
+  nixpkgs.config.nvidia.acceptLicense = true;
+
   environment.systemPackages = [ nvidia-offload ];
 
   services.xserver.videoDrivers = [ "nvidia" ];
   hardware = {
     opengl.enable = true;
     nvidia = {
-      package = config.boot.kernelPackages.nvidiaPackages.production;
+      package = config.boot.kernelPackages.nvidiaPackages.dc_535;
       prime = {
         offload.enable = true;
         intelBusId = "PCI:0:2:0";

--- a/modules/hardware/xps/nvidia.nix
+++ b/modules/hardware/xps/nvidia.nix
@@ -5,7 +5,7 @@
 #  For GeForce GTX 1650 Ti
 #
 
-{ config, pkgs, unstable, ... }:
+{ config, pkgs, ... }:
 
 let
   nvidia-offload = pkgs.writeShellScriptBin "nvidia-offload" ''
@@ -17,13 +17,15 @@ let
   '';
 in
 {
+  nixpkgs.config.nvidia.acceptLicense = true;
+
   environment.systemPackages = [ nvidia-offload ];
 
   services.xserver.videoDrivers = [ "nvidia" ];
   hardware = {
     opengl = {
       enable = true;
-      package = unstable.mesa.drivers;
+      # package = pkgs.mesa.drivers;
     };
     nvidia = {
       package = config.boot.kernelPackages.nvidiaPackages.production;

--- a/modules/programs/eww.nix
+++ b/modules/programs/eww.nix
@@ -7,7 +7,7 @@
 {
   config = lib.mkIf (config.wlwm.enable) {
     environment.systemPackages = with pkgs; [
-      eww-wayland # Widgets
+      eww # Widgets
       jq # JSON Processor
       socat # Data Transfer
     ];

--- a/modules/programs/waybar.nix
+++ b/modules/programs/waybar.nix
@@ -2,7 +2,7 @@
 #  Bar
 #
 
-{ config, lib, pkgs, unstable, vars, host, ... }:
+{ config, lib, pkgs, vars, host, ... }:
 let
   colors = import ../theming/colors.nix;
 in
@@ -69,14 +69,14 @@ let
 in
 {
   config = lib.mkIf (config.wlwm.enable) {
-    environment.systemPackages = with unstable; [
+    environment.systemPackages = with pkgs; [
       waybar
     ];
 
     home-manager.users.${vars.user} = with colors.scheme.default; {
       programs.waybar = {
         enable = true;
-        package = unstable.waybar;
+        package = pkgs.waybar;
         # systemd = {
         #   enable = true;
         #   target = "hyprland-session.target";
@@ -176,7 +176,7 @@ in
             };
             "custom/menu" = {
               format = "<span font='16'></span>";
-              # on-click = ''${pkgs.eww-wayland}/bin/eww open --toggle menu --screen 0'';
+              # on-click = ''${pkgs.eww}/bin/eww open --toggle menu --screen 0'';
               on-click = ''sleep 0.1; .config/wofi/power.sh'';
               on-click-right = "sleep 0.1; ${pkgs.wofi}/bin/wofi --show drun";
               tooltip = false;
@@ -246,7 +246,7 @@ in
             };
             clock = {
               format = "{:%b %d %H:%M}  ";
-              on-click = "sleep 0.1; ${pkgs.eww-wayland}/bin/eww open --toggle calendar --screen 0";
+              on-click = "sleep 0.1; ${pkgs.eww}/bin/eww open --toggle calendar --screen 0";
             };
             cpu = {
               format = " {usage}% <span font='11'></span> ";
@@ -287,12 +287,12 @@ in
               tooltip-format = "{essid} {ipaddr}/{cidr}";
             };
             pulseaudio = {
-              format = "<span font='11'>{icon}</span> {volume}% {format_source} ";
-              format-bluetooth = "<span font='11'>{icon}</span> {volume}% {format_source} ";
-              format-bluetooth-muted = "<span font='11'>x</span> {volume}% {format_source} ";
-              format-muted = "<span font='11'>x</span> {volume}% {format_source} ";
-              format-source = "<span font='10'></span> ";
-              format-source-muted = "<span font='11'></span> ";
+              format = "<span font='13'>{icon}</span> {volume}% {format_source} ";
+              format-bluetooth = "<span font='13'>{icon}</span> {volume}% {format_source} ";
+              format-bluetooth-muted = "<span font='13'>x</span> {volume}% {format_source} ";
+              format-muted = "<span font='13'>x</span> {volume}% {format_source} ";
+              format-source = "<span font='14'></span> ";
+              format-source-muted = "<span font='14'></span> ";
               format-icons = {
                 default = [ "" "" "" ];
                 headphone = "";

--- a/modules/services/avahi.nix
+++ b/modules/services/avahi.nix
@@ -6,7 +6,7 @@
   services = {
     avahi = {
       enable = true;
-      nssmdns = true;
+      nssmdns4 = true;
       publish = {
         enable = true;
         addresses = true;

--- a/modules/theming/theming.nix
+++ b/modules/theming/theming.nix
@@ -42,10 +42,14 @@
       };
     };
 
-    qt.enable = true;
-    qt.platformTheme = "gtk";
-    qt.style.name = "adwaita-dark";
-    qt.style.package = pkgs.adwaita-qt;
+    qt = {
+      enable = true;
+      platformTheme.name = "gtk";
+      style = {
+        name = "adwaita-dark";
+        package = pkgs.adwaita-qt;
+      };
+    };
   };
 
   environment.variables = {

--- a/nixos.org
+++ b/nixos.org
@@ -209,9 +209,9 @@
     keyMap = "...";                           # us / fr / azerty / etc...
   };
   # XServer layout (possibly also sets console now)
-  services.xserver.layout = "..."             # us / fr / be / etc..
+  services.xserver.xkb.layout = "..."             # us / fr / be / etc..
   # Extra keyboard settings:
-  services.xserver.xkbOptions = "eurosign:e"; # For example adds €
+  services.xserver.xkb.options = "eurosign:e"; # For example adds €
 #+end_src
 
 **** Display Managers/Desktop Environments/Window Managers


### PR DESCRIPTION
Switch all hosts to use nixos-unstable by default.
Packages can still be installed via `stable` instead of `pkgs`.